### PR TITLE
added support for key prefix / namespacing

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,6 +66,9 @@ type Config struct {
 
 	// TLS Config to use. When set TLS will be negotiated.
 	TLSConfig *tls.Config
+
+	//KeyNamespace used for prefixing/namespacing keys.
+	KeyNamespace string
 }
 
 func (o *Config) redisOptions() *redis.Options {

--- a/token_test.go
+++ b/token_test.go
@@ -97,3 +97,92 @@ func TestTokenStore(t *testing.T) {
 		})
 	})
 }
+
+func TestTokenStoreWithKeyNamespace(t *testing.T) {
+	Convey("Test redis token store", t, func() {
+		cfg := &redis.Config{
+			Addr:         "127.0.0.1:6379",
+			KeyNamespace: "test:",
+		}
+		store, err := redis.NewTokenStore(cfg)
+		So(err, ShouldBeNil)
+
+		Convey("Test authorization code store", func() {
+			info := &models.Token{
+				ClientID:      "1",
+				UserID:        "1_1",
+				RedirectURI:   "http://localhost/",
+				Scope:         "all",
+				Code:          "11_11_11",
+				CodeCreateAt:  time.Now(),
+				CodeExpiresIn: time.Second * 5,
+			}
+			err := store.Create(info)
+			So(err, ShouldBeNil)
+
+			cinfo, err := store.GetByCode(info.Code)
+			So(err, ShouldBeNil)
+			So(cinfo.GetUserID(), ShouldEqual, info.UserID)
+
+			err = store.RemoveByCode(info.Code)
+			So(err, ShouldBeNil)
+
+			cinfo, err = store.GetByCode(info.Code)
+			So(err, ShouldBeNil)
+			So(cinfo, ShouldBeNil)
+		})
+
+		Convey("Test access token store", func() {
+			info := &models.Token{
+				ClientID:        "1",
+				UserID:          "1_1",
+				RedirectURI:     "http://localhost/",
+				Scope:           "all",
+				Access:          "1_1_1",
+				AccessCreateAt:  time.Now(),
+				AccessExpiresIn: time.Second * 5,
+			}
+			err := store.Create(info)
+			So(err, ShouldBeNil)
+
+			ainfo, err := store.GetByAccess(info.GetAccess())
+			So(err, ShouldBeNil)
+			So(ainfo.GetUserID(), ShouldEqual, info.GetUserID())
+
+			err = store.RemoveByAccess(info.GetAccess())
+			So(err, ShouldBeNil)
+
+			ainfo, err = store.GetByAccess(info.GetAccess())
+			So(err, ShouldBeNil)
+			So(ainfo, ShouldBeNil)
+		})
+
+		Convey("Test refresh token store", func() {
+			info := &models.Token{
+				ClientID:         "1",
+				UserID:           "1_2",
+				RedirectURI:      "http://localhost/",
+				Scope:            "all",
+				Access:           "1_2_1",
+				AccessCreateAt:   time.Now(),
+				AccessExpiresIn:  time.Second * 5,
+				Refresh:          "1_2_2",
+				RefreshCreateAt:  time.Now(),
+				RefreshExpiresIn: time.Second * 15,
+			}
+			err := store.Create(info)
+			So(err, ShouldBeNil)
+
+			rinfo, err := store.GetByRefresh(info.GetRefresh())
+			So(err, ShouldBeNil)
+			So(rinfo.GetUserID(), ShouldEqual, info.GetUserID())
+
+			err = store.RemoveByRefresh(info.GetRefresh())
+			So(err, ShouldBeNil)
+
+			rinfo, err = store.GetByRefresh(info.GetRefresh())
+			So(err, ShouldBeNil)
+			So(rinfo, ShouldBeNil)
+		})
+	})
+}


### PR DESCRIPTION
Couple of nice things
1. Easier to find/delete all keys associated with the tokens if the redis is used by other services
2. Support for multi tenant to the same redis.
3. Doesn't break compatibility