### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: go
-sudo: false
 go_import_path: gopkg.in/go-oauth2/redis.v3
-go:
-  - 1.9
+matrix:
+  include:
+    - go: "1.9.7"
+    - go: 1.13.x
+      env: GO111MODULE=on
 services:
-  - redis-server
+  - redis
 before_install:
   - go get -t -v ./...
 


### PR DESCRIPTION
This PR fixes travis builds.

Build against the legacy 1.9.7 and 1.13 go versions. 1.9.7 is the oldest go version that supports modules (and the first in 1.9.x release that does it). `go.mod` specifies the latter version.

Also, removed deprecated `sudo` key (which does nothing) and renamed redis' sevice name (an alias was used before).

**UPD**: I wanted to upgrade the redis go package to `v7` as well (since they now use go modules correctly, i.e. they added `v7` prefix to the package path), but that is a major change and, according to semver, would require the change of the major version.