### PR TITLE
Keep access exp time when refresh time is 0

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -191,8 +191,10 @@ func (s *TokenStore) Create(ctx context.Context, info oauth2.TokenInfo) error {
 
 		if refresh := info.GetRefresh(); refresh != "" {
 			rexp = info.GetRefreshCreateAt().Add(info.GetRefreshExpiresIn()).Sub(ct)
-			if aexp.Seconds() > rexp.Seconds() {
-				aexp = rexp
+			if rexp.Seconds() > 0 {
+				if aexp.Seconds() > rexp.Seconds() {
+					aexp = rexp
+				}
 			}
 			pipe.Set(ctx, s.wrapperKey(refresh), basicID, rexp)
 		}


### PR DESCRIPTION
When refresh token expiration time is 0, which means unlimited, the access token expiration should keep its original value.